### PR TITLE
Fix #16 - java not found

### DIFF
--- a/pybble/cli.py
+++ b/pybble/cli.py
@@ -15,11 +15,16 @@ def cli():
 @click.argument('file')
 @click.option('--copy', is_flag=True, help='Copies compiled, minified '
                                            'javascript to system clipboard.')
-def build(file, copy):
+@click.option('--nomin', is_flag=True, help='Disable minifier (use if no JRE/JVM), passes -n/--nomin to transcrypt')
+def build(file, copy, nomin):
     click.echo('Transpiling to Javascript...')
-    t = envoy.run('transcrypt -p .none {}'.format(file))
+    options = []
+    if nomin:
+        options += ['--nomin']
+    t = envoy.run('transcrypt {} -p .none {}'.format(' '.join(options), file))  # --nomin means larger js file BUT does not need java (minifier)
 
     if t.status_code != 0:
+        print('transcrypt compile error!')
         click.echo(t.std_out)
         sys.exit(-1)
 
@@ -29,7 +34,11 @@ def build(file, copy):
         basename = os.path.basename(file)
         basename = os.path.splitext(basename)[0]
         basedir = os.path.dirname(file)
-        fpath = os.path.join(basedir, '__javascript__/{}.min.js'.format(basename))
+        # NOTE transcrypt version 3.6 emits to '__javascript__' directory, later versions (3.9) goto '__target__' directory
+        if nomin:
+            fpath = os.path.join(basedir, '__javascript__/{}.js'.format(basename))  # nomin version, i.e original un-minified version
+        else:
+            fpath = os.path.join(basedir, '__javascript__/{}.min.js'.format(basename))  # minified version
         with open(fpath, 'r') as minfile:
             pyperclip.copy(minfile.read())
 


### PR DESCRIPTION
* Add support to skip minifier stage in Transcrypt with new flag `--nomin` (same as used by Transcrypt)
* Make clear when Transcrypt error occurs
* pick up the correct filename when nomin specified